### PR TITLE
✨ Add support for multiple kind of source

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,14 @@ WORKDIR /workspace
 
 RUN poetry install
 
-ENV K8S_STATE_SOURCE_URL ""
-ENV K8S_STATE_SOURCE_REF ""
+VOLUME /data
+
+ENV K8S_STATE_SOURCE_KIND "local"
+
+ENV K8S_STATE_SOURCE_LOCAL_DIR "/data"
+
+ENV K8S_STATE_SOURCE_GIT_URL ""
+ENV K8S_STATE_SOURCE_GIT_REF "main"
+ENV K8S_STATE_SOURCE_GIT_DIR "."
 
 CMD [ "poetry", "run", "ansible-playbook", "site.yml" ]

--- a/library/include_k8s_source_vars
+++ b/library/include_k8s_source_vars
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3.9
+
+from ansible.module_utils.basic import AnsibleModule
+import jsonschema
+import yaml
+import os
+
+
+SCHEMA = dict(
+    type='object',
+    properties=dict(
+        tools=dict(
+            type='array',
+            items=dict(type='string'),
+            default=[]
+        ),
+        bundles=dict(
+            type='array',
+            items=dict(
+                type='object',
+                required=['name'],
+                properties=dict(
+                    name=dict(type='string')
+                )
+            ),
+            default=[]
+        ),
+        applications=dict(
+            type='array',
+            items=dict(
+                type='object',
+                required=['name'],
+                properties=dict(
+                    name=dict(type='string')
+                )
+            ),
+            default=[]
+        )
+    )
+)
+
+
+def extend_with_defaults(validator_class):
+    validate_properties = validator_class.VALIDATORS['properties']
+
+    def set_defaults(validator, properties, instance, schema):
+        for property, subschema in properties.items():
+            if 'default' in subschema:
+                instance.setdefault(property, subschema['default'])
+
+        errors = validate_properties(validator, properties, instance, schema)
+
+        for error in errors:
+            yield error
+
+    return jsonschema.validators.extend(
+        validator_class,
+        dict(properties= set_defaults)
+    )
+
+
+Validator = extend_with_defaults(jsonschema.Draft7Validator)
+
+
+def run_module():
+    module_args = dict(
+        location=dict(type='str', required=True)
+    )
+
+    result = dict(
+        changed=False,
+        ansible_facts={}
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=False
+    )
+
+    location = os.path.join(module.params['location'], 'vars.yml')
+
+    if not os.path.exists(location):
+        module.fail_json(msg=f'{location} not found')
+
+    else:
+        try:
+            with open(location) as f:
+                variables = yaml.safe_load(f)
+
+            Validator(SCHEMA).validate(variables)
+
+            for package_kind in ['bundles', 'applications']:
+                for package in variables[package_kind]:
+                    package_dir = os.path.join(
+                        location,
+                        package_kind,
+                        package['name']
+                    )
+
+                    if not os.path.exists(package_dir):
+                        raise Exception(f'{package_dir} not found')
+
+                    if not os.path.isdir(package_dir):
+                        raise Exception(f'{package_dir} is not a directory')
+
+            result['ansible_facts']['k8s_state_source_vars'] = variables
+
+        except Exception as err:
+            module.fail_json(
+                msg=f'Impossible to load \'{location}\': {err}',
+                **result
+            )
+
+        else:
+            module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    run_module()

--- a/library/set_k8s_source_facts
+++ b/library/set_k8s_source_facts
@@ -40,9 +40,12 @@ class KubernetesSources:
     def local():
         location = os.getenv(EnvVars.local_dir)
 
-        if not location or not os.path.exists(location):
+        if not location \
+            or not os.path.exists(location) \
+            or not os.path.isabs(location):
+
             raise Exception(
-                f'Missing environment variable: {EnvVars.local_dir}'
+                f'Invalid value for environment variable: {EnvVars.local_dir}'
             )
 
         return {

--- a/library/set_k8s_source_facts
+++ b/library/set_k8s_source_facts
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3.9
+
+from ansible.module_utils.basic import AnsibleModule
+import os
+
+
+class EnvVars:
+    git_url = 'K8S_STATE_SOURCE_GIT_URL'
+    git_ref = 'K8S_STATE_SOURCE_GIT_REF'
+    git_folder = 'K8S_STATE_SOURCE_GIT_DIR'
+
+    local_dir = 'K8S_STATE_SOURCE_LOCAL_DIR'
+
+
+class Facts:
+    git_url = 'k8s_state_source_git_url'
+    git_ref = 'k8s_state_source_git_ref'
+    git_folder = 'k8s_state_source_git_dir'
+
+    local_dir = 'k8s_state_source_local_dir'
+
+
+class KubernetesSources:
+    @staticmethod
+    def git():
+        url = os.getenv(EnvVars.git_url)
+        ref = os.getenv(EnvVars.git_ref, 'main')
+        folder = os.getenv(EnvVars.git_folder, '.')
+
+        if not url:
+            raise Exception(f'Missing environment variable: {EnvVars.git_url}')
+
+        return {
+            Facts.git_url: url,
+            Facts.git_ref: ref,
+            Facts.git_folder: folder
+        }
+
+    @staticmethod
+    def local():
+        location = os.getenv(EnvVars.local_dir)
+
+        if not location or not os.path.exists(location):
+            raise Exception(
+                f'Missing environment variable: {EnvVars.local_dir}'
+            )
+
+        return {
+            Facts.local_dir: location
+        }
+
+
+def run_module():
+    module_args = dict(
+        kind=dict(type='str', required=True)
+    )
+
+    result = dict(
+        changed=False,
+        ansible_facts={}
+    )
+
+    module = AnsibleModule(
+        argument_spec=module_args,
+        supports_check_mode=False
+    )
+
+    kind = module.params['kind']
+    handler = getattr(KubernetesSources, kind, None)
+
+    if handler is None:
+        module.fail_json(msg=f'Unknown Kubernetes Source \'{kind}\'', **result)
+
+    try:
+        result['ansible_facts'] = handler()
+        result['ansible_facts']['k8s_state_source_kind'] = kind
+
+    except Exception as err:
+        module.fail_json(
+            msg=f'Impossible to validate Kubernetes Source \'{kind}\': {err}',
+            **result
+        )
+
+    else:
+        module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    run_module()

--- a/poetry.lock
+++ b/poetry.lock
@@ -24,6 +24,20 @@ packaging = "*"
 PyYAML = "*"
 
 [[package]]
+name = "attrs"
+version = "21.2.0"
+description = "Classes Without Boilerplate"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[package.extras]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit"]
+docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins"]
+
+[[package]]
 name = "cffi"
 version = "1.14.5"
 description = "Foreign Function Interface for Python calling C code."
@@ -68,6 +82,23 @@ MarkupSafe = ">=0.23"
 i18n = ["Babel (>=0.8)"]
 
 [[package]]
+name = "jsonschema"
+version = "3.2.0"
+description = "An implementation of JSON Schema validation for Python"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+attrs = ">=17.4.0"
+pyrsistent = ">=0.14.0"
+six = ">=1.11.0"
+
+[package.extras]
+format = ["idna", "jsonpointer (>1.13)", "rfc3987", "strict-rfc3339", "webcolors"]
+format_nongpl = ["idna", "jsonpointer (>1.13)", "webcolors", "rfc3986-validator (>0.1.0)", "rfc3339-validator"]
+
+[[package]]
 name = "markupsafe"
 version = "2.0.0"
 description = "Safely add untrusted strings to HTML/XML markup."
@@ -103,6 +134,14 @@ optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
+name = "pyrsistent"
+version = "0.17.3"
+description = "Persistent/Functional/Immutable data structures"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
 name = "pyyaml"
 version = "5.4.1"
 description = "YAML parser and emitter for Python"
@@ -110,10 +149,18 @@ category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 
+[[package]]
+name = "six"
+version = "1.16.0"
+description = "Python 2 and 3 compatibility utilities"
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "c0302295531aa8b5ebd71ded137d3f201d9c18f0f83b28a0c00e42d86f24e865"
+content-hash = "bca3ec82e1376ecdc2d08b22992342fe64e0ba8e6ff16886077fbf426bccdf74"
 
 [metadata.files]
 ansible = [
@@ -121,6 +168,10 @@ ansible = [
 ]
 ansible-base = [
     {file = "ansible-base-2.10.9.tar.gz", hash = "sha256:04635d3e08fc29358c76b8e7f1e9db0ce443fb09ce30b2acc6cacaad165f2151"},
+]
+attrs = [
+    {file = "attrs-21.2.0-py2.py3-none-any.whl", hash = "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1"},
+    {file = "attrs-21.2.0.tar.gz", hash = "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"},
 ]
 cffi = [
     {file = "cffi-1.14.5-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:bb89f306e5da99f4d922728ddcd6f7fcebb3241fc40edebcb7284d7514741991"},
@@ -179,6 +230,10 @@ jinja2 = [
     {file = "Jinja2-2.11.3-py2.py3-none-any.whl", hash = "sha256:03e47ad063331dd6a3f04a43eddca8a966a26ba0c5b7207a9a9e4e08f1b29419"},
     {file = "Jinja2-2.11.3.tar.gz", hash = "sha256:a6d58433de0ae800347cab1fa3043cebbabe8baa9d29e668f1c768cb87a333c6"},
 ]
+jsonschema = [
+    {file = "jsonschema-3.2.0-py2.py3-none-any.whl", hash = "sha256:4e5b3cf8216f577bee9ce139cbe72eca3ea4f292ec60928ff24758ce626cd163"},
+    {file = "jsonschema-3.2.0.tar.gz", hash = "sha256:c8a85b28d377cc7737e46e2d9f2b4f44ee3c0e1deac6bf46ddefc7187d30797a"},
+]
 markupsafe = [
     {file = "MarkupSafe-2.0.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:2efaeb1baff547063bad2b2893a8f5e9c459c4624e1a96644bbba08910ae34e0"},
     {file = "MarkupSafe-2.0.0-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:441ce2a8c17683d97e06447fcbccbdb057cbf587c78eb75ae43ea7858042fe2c"},
@@ -227,6 +282,9 @@ pyparsing = [
     {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
     {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
 ]
+pyrsistent = [
+    {file = "pyrsistent-0.17.3.tar.gz", hash = "sha256:2e636185d9eb976a18a8a8e96efce62f2905fea90041958d8cc2a189756ebf3e"},
+]
 pyyaml = [
     {file = "PyYAML-5.4.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:3b2b1824fe7112845700f815ff6a489360226a5609b96ec2190a45e62a9fc922"},
     {file = "PyYAML-5.4.1-cp27-cp27m-win32.whl", hash = "sha256:129def1b7c1bf22faffd67b8f3724645203b79d8f4cc81f674654d9902cb4393"},
@@ -257,4 +315,8 @@ pyyaml = [
     {file = "PyYAML-5.4.1-cp39-cp39-win32.whl", hash = "sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10"},
     {file = "PyYAML-5.4.1-cp39-cp39-win_amd64.whl", hash = "sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db"},
     {file = "PyYAML-5.4.1.tar.gz", hash = "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e"},
+]
+six = [
+    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
+    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ python = "^3.9"
 ansible = "^3.4.0"
 Jinja2 = "^2.11.3"
 PyYAML = "^5.4.1"
+jsonschema = "^3.2.0"
 
 [tool.poetry.dev-dependencies]
 

--- a/roles/k8s-source/tasks/main.yml
+++ b/roles/k8s-source/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+
+- name: gather k8s state source facts
+  set_k8s_source_facts:
+    kind: '{{ lookup("env", "K8S_STATE_SOURCE_KIND") | default(None) }}'
+
+- name: load k8s state source
+  include_tasks: 'sources/{{ k8s_state_source_kind }}.yml'
+
+- name: load k8s state source variables
+  include_k8s_source_vars:
+    location: "{{ k8s_state_source_location }}"

--- a/roles/k8s-source/tasks/sources/git.yml
+++ b/roles/k8s-source/tasks/sources/git.yml
@@ -1,0 +1,13 @@
+---
+
+- name: "git : clone k8s state source"
+  git:
+    repo: "{{ k8s_state_source_git_url }}"
+    version: "{{ k8s_state_source_git_ref }}"
+    accept_hostkey: yes
+    depth: "1"
+    dest: "{{ playbook_dir }}/cache/k8s-state-source"
+
+- name: "git : configure k8s state source location"
+  set_fact:
+    k8s_state_source_location: "{{ playbook_dir }}/cache/k8s-state-source/{{ k8s_state_source_git_dir }}"

--- a/roles/k8s-source/tasks/sources/local.yml
+++ b/roles/k8s-source/tasks/sources/local.yml
@@ -1,0 +1,5 @@
+---
+
+- name: "local : configure k8s state source location"
+  set_fact:
+    k8s_state_source_location: "{{ k8s_state_source_local_dir }}"

--- a/roles/k8s-state/tasks/application.yml
+++ b/roles/k8s-state/tasks/application.yml
@@ -1,11 +1,5 @@
 ---
 
-- name: "{{ k8s_application.name }} : verify application parameters"
-  assert:
-    that:
-      - k8s_application.name is string
-      - "'{{ playbook_dir }}/cache/k8s-state-source/apps/{{ k8s_application.name }}' is exists"
-
 - name: "{{ k8s_application.name }} : create namespace"
   shell:
     cmd: |
@@ -23,5 +17,5 @@
   changed_when: false
 
 - name: "{{ k8s_application.name }} : deploy application"
-  shell: kapp deploy -n 'klifter-system-app-{{ k8s_application.name }}' -a '{{ k8s_application.name }}' -f '{{ playbook_dir }}/cache/k8s-state-source/apps/{{ k8s_application.name }}'
+  shell: kapp deploy -n 'klifter-system-app-{{ k8s_application.name }}' -a '{{ k8s_application.name }}' -f '{{ k8s_state_source_location }}/apps/{{ k8s_application.name }}'
   changed_when: false

--- a/roles/k8s-state/tasks/bundle.yml
+++ b/roles/k8s-state/tasks/bundle.yml
@@ -3,7 +3,7 @@
 - name: "{{ k8s_bundle.name }} : find bundle manifests"
   find:
     paths:
-      - "{{ k8s_state_source_location }}/{{ k8s_bundle.name }}"
+      - "{{ k8s_state_source_location }}/bundles/{{ k8s_bundle.name }}"
     recurse: yes
   register: k8s_bundle_manifests
 

--- a/roles/k8s-state/tasks/bundle.yml
+++ b/roles/k8s-state/tasks/bundle.yml
@@ -1,15 +1,9 @@
 ---
 
-- name: "{{ k8s_bundle.name }} : verify bundle parameters"
-  assert:
-    that:
-      - k8s_bundle.name is string
-      - "'{{ playbook_dir }}/cache/k8s-state-source/bundles/{{ k8s_bundle.name }}' is exists"
-
 - name: "{{ k8s_bundle.name }} : find bundle manifests"
   find:
     paths:
-      - "{{ playbook_dir }}/cache/k8s-state-source/{{ k8s_bundle.name }}"
+      - "{{ k8s_state_source_location }}/{{ k8s_bundle.name }}"
     recurse: yes
   register: k8s_bundle_manifests
 

--- a/roles/k8s-state/tasks/main.yml
+++ b/roles/k8s-state/tasks/main.yml
@@ -1,25 +1,5 @@
 ---
 
-- name: clone k8s state source
-  git:
-    repo: "{{ k8s_state_source_url }}"
-    version: "{{ k8s_state_source_ref }}"
-    accept_hostkey: yes
-    depth: "1"
-    dest: "{{ playbook_dir }}/cache/k8s-state-source"
-
-- name: load k8s state source variables
-  include_vars:
-    file: "{{ playbook_dir }}/cache/k8s-state-source/vars.yml"
-    name: k8s_state_source_vars
-
-- name: verify k8s state source variables
-  assert:
-    that:
-      - k8s_state_source_vars.tools is sequence
-      - k8s_state_source_vars.bundles is sequence
-      - k8s_state_source_vars.applications is sequence
-
 - name: install tools
   include_tasks: tools/{{ k8s_tool }}.yml
   loop: "{{ k8s_state_default_tools + k8s_state_source_vars.tools }}"

--- a/roles/k8s-state/tasks/manifests/kubernetes.yml
+++ b/roles/k8s-state/tasks/manifests/kubernetes.yml
@@ -3,7 +3,7 @@
 - name: "{{ k8s_bundle.name }} : deploy Kubernetes manifest : {{ k8s_bundle_manifest }}"
   shell:
     cmd: kubectl apply -f '{{ k8s_bundle_manifest }}'
-    chdir: "{{ playbook_dir }}/cache/k8s-state-source"
+    chdir: "{{ k8s_state_source_location }}"
   changed_when: false
   register: result
   retries: 5

--- a/roles/k8s-state/tasks/manifests/shell.yml
+++ b/roles/k8s-state/tasks/manifests/shell.yml
@@ -3,7 +3,7 @@
 - name: "{{ k8s_bundle.name }} : run Shell Script : {{ k8s_bundle_manifest }}"
   shell:
     cmd: bash '{{ k8s_bundle_manifest }}'
-    chdir: "{{ playbook_dir }}/cache/k8s-state-source"
+    chdir: "{{ k8s_state_source_location }}"
   changed_when: false
   register: result
   retries: 5

--- a/site.yml
+++ b/site.yml
@@ -1,22 +1,8 @@
 ---
 
-- name: build inventory
-  hosts: localhost
-  connection: local
-  tasks:
-    - name: get state source
-      set_fact:
-        k8s_state_source_url: '{{ lookup("env", "K8S_STATE_SOURCE_URL") | default(None) }}'
-        k8s_state_source_ref: '{{ lookup("env", "K8S_STATE_SOURCE_REF") | default(None) }}'
-
-    - name: verify state source
-      assert:
-        that:
-          - '{{ k8s_state_source_url | length }} > 0'
-          - '{{ k8s_state_source_ref | length }} > 0'
-
 - name: apply desired state
   hosts: localhost
   connection: local
   roles:
+    - k8s-source
     - k8s-state


### PR DESCRIPTION
This PR provides the following changes:

 - [x] :sparkles: Add module `set_k8s_source_facts` to parse environment variables into Ansible facts
 - [x] :sparkles: Add module `include_k8s_source_vars` to parse and validate the `vars.yml` file from the source
 - [x] :sparkles: Add role `k8s-source` to load the desired state
 - [x] :sparkles: Add support for `local` source kind in addition to the `git` source kind

| Environment Variable | Description | Required | Default Value |
| --- | --- | --- | --- |
| K8S_STATE_SOURCE_KIND | Either `git` or `local` | ✅ | N/A |

If it is set to `git`:

| Environment Variable | Description | Required | Default Value |
| --- | --- | --- | --- |
| K8S_STATE_SOURCE_GIT_URL | URL to the Git repository to clone | ✅ | N/A |
| K8S_STATE_SOURCE_GIT_REF | Branch, tag or commit to clone | ❌  | `main` |
| K8S_STATE_SOURCE_GIT_DIR | Directory within the repository containing the source | ❌ | `.` |

If it is set to `local`:
| Environment Variable | Description | Required | Default Value |
| --- | --- | --- | --- |
| K8S_STATE_SOURCE_LOCAL_DIR | Absolute path to the folder containing the source | ✅ | N/A |
