### PR TITLE
🔨🐛 Merge bundles and applications into a single list

### DIFF
--- a/library/include_k8s_source_vars
+++ b/library/include_k8s_source_vars
@@ -14,24 +14,14 @@ SCHEMA = dict(
             items=dict(type='string'),
             default=[]
         ),
-        bundles=dict(
+        packages=dict(
             type='array',
             items=dict(
                 type='object',
-                required=['name'],
+                required=['name', 'kind'],
                 properties=dict(
-                    name=dict(type='string')
-                )
-            ),
-            default=[]
-        ),
-        applications=dict(
-            type='array',
-            items=dict(
-                type='object',
-                required=['name'],
-                properties=dict(
-                    name=dict(type='string')
+                    name=dict(type='string'),
+                    kind=dict(enum=['bundle', 'application'])
                 )
             ),
             default=[]
@@ -89,19 +79,18 @@ def run_module():
 
             Validator(SCHEMA).validate(variables)
 
-            for package_kind in ['bundles', 'applications']:
-                for package in variables[package_kind]:
-                    package_dir = os.path.join(
-                        location,
-                        package_kind,
-                        package['name']
-                    )
+            for package in variables['packages']:
+                package_dir = os.path.join(
+                    location,
+                    package['kind'],
+                    package['name']
+                )
 
-                    if not os.path.exists(package_dir):
-                        raise Exception(f'{package_dir} not found')
+                if not os.path.exists(package_dir):
+                    raise Exception(f'{package_dir} not found')
 
-                    if not os.path.isdir(package_dir):
-                        raise Exception(f'{package_dir} is not a directory')
+                if not os.path.isdir(package_dir):
+                    raise Exception(f'{package_dir} is not a directory')
 
             result['ansible_facts']['k8s_state_source_vars'] = variables
 

--- a/roles/k8s-state/tasks/application.yml
+++ b/roles/k8s-state/tasks/application.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: "{{ k8s_application.name }} : create namespace"
+- name: "{{ k8s_package.name }} : create namespace"
   shell:
     cmd: |
       cat <<EOF | kubectl apply -f -
@@ -8,14 +8,14 @@
       apiVersion: v1
       kind: Namespace
       metadata:
-        name: klifter-system-app-{{ k8s_application.name }}
+        name: klifter-system-app-{{ k8s_package.name }}
         labels:
           app.kubernetes.io/managed-by: klifter
           app.kubernetes.io/component: application
-          app.kubernetes.io/name: {{ k8s_application.name }}
+          app.kubernetes.io/name: {{ k8s_package.name }}
       EOF
   changed_when: false
 
-- name: "{{ k8s_application.name }} : deploy application"
-  shell: kapp deploy -n 'klifter-system-app-{{ k8s_application.name }}' -a '{{ k8s_application.name }}' -f '{{ k8s_state_source_location }}/apps/{{ k8s_application.name }}'
+- name: "{{ k8s_package.name }} : deploy application"
+  shell: kapp deploy -n 'klifter-system-app-{{ k8s_package.name }}' -a '{{ k8s_package.name }}' -f '{{ k8s_state_source_location }}/apps/{{ k8s_package.name }}'
   changed_when: false

--- a/roles/k8s-state/tasks/bundle.yml
+++ b/roles/k8s-state/tasks/bundle.yml
@@ -1,14 +1,14 @@
 ---
 
-- name: "{{ k8s_bundle.name }} : find bundle manifests"
+- name: "{{ k8s_package.name }} : find bundle manifests"
   find:
     paths:
-      - "{{ k8s_state_source_location }}/bundles/{{ k8s_bundle.name }}"
+      - "{{ k8s_state_source_location }}/bundles/{{ k8s_package.name }}"
     recurse: yes
-  register: k8s_bundle_manifests
+  register: k8s_package_manifests
 
-- name: "{{ k8s_bundle.name }} : deploy bundle manifests"
+- name: "{{ k8s_package.name }} : deploy bundle manifests"
   include_tasks: manifest.yml
-  loop: '{{ k8s_bundle_manifests.files | map(attribute="path") | sort }}'
+  loop: '{{ k8s_package_manifests.files | map(attribute="path") | sort }}'
   loop_control:
-    loop_var: k8s_bundle_manifest
+    loop_var: k8s_package_manifest

--- a/roles/k8s-state/tasks/main.yml
+++ b/roles/k8s-state/tasks/main.yml
@@ -6,14 +6,8 @@
   loop_control:
     loop_var: k8s_tool
 
-- name: deploy bundles
-  include_tasks: bundle.yml
-  loop: "{{ k8s_state_source_vars.bundles }}"
+- name: deploy packages
+  include_tasks: "{{ package.kind }}.yml"
+  loop: "{{ k8s_state_source_vars.packages }}"
   loop_control:
-    loop_var: k8s_bundle
-
-- name: deploy applications
-  include_tasks: application.yml
-  loop: "{{ k8s_state_source_vars.apps }}"
-  loop_control:
-    loop_var: k8s_application
+    loop_var: k8s_package

--- a/roles/k8s-state/tasks/manifests/kubernetes.yml
+++ b/roles/k8s-state/tasks/manifests/kubernetes.yml
@@ -1,8 +1,8 @@
 ---
 
-- name: "{{ k8s_bundle.name }} : deploy Kubernetes manifest : {{ k8s_bundle_manifest }}"
+- name: "{{ k8s_package.name }} : deploy Kubernetes manifest : {{ k8s_package_manifest }}"
   shell:
-    cmd: kubectl apply -f '{{ k8s_bundle_manifest }}'
+    cmd: kubectl apply -f '{{ k8s_package_manifest }}'
     chdir: "{{ k8s_state_source_location }}"
   changed_when: false
   register: result

--- a/roles/k8s-state/tasks/manifests/shell.yml
+++ b/roles/k8s-state/tasks/manifests/shell.yml
@@ -1,8 +1,8 @@
 ---
 
-- name: "{{ k8s_bundle.name }} : run Shell Script : {{ k8s_bundle_manifest }}"
+- name: "{{ k8s_package.name }} : run Shell Script : {{ k8s_package_manifest }}"
   shell:
-    cmd: bash '{{ k8s_bundle_manifest }}'
+    cmd: bash '{{ k8s_package_manifest }}'
     chdir: "{{ k8s_state_source_location }}"
   changed_when: false
   register: result

--- a/roles/k8s-state/tasks/manifests/unknown.yml
+++ b/roles/k8s-state/tasks/manifests/unknown.yml
@@ -1,5 +1,5 @@
 ---
 
-- name: "{{ k8s_bundle.name }} : ignore : {{ k8s_bundle_manifest }}"
+- name: "{{ k8s_package.name }} : ignore : {{ k8s_package_manifest }}"
   shell: "true"
   changed_when: false


### PR DESCRIPTION
This PR provides the following changes:

 - [x] :hammer: Merge `bundles` and `applications` into a single list `packages`
 - [x] :sparkles: Add property `kind` to packages items

This also fixes:

 - [x] :bug: The `manifest.yml` was still using `k8s_package` variable instead of `k8s_bundle`