### PR TITLE
🔒 Non root Docker image

### DIFF
--- a/roles/k8s-state/tasks/manifests/shell.yml
+++ b/roles/k8s-state/tasks/manifests/shell.yml
@@ -1,6 +1,8 @@
 ---
 
 - name: "{{ k8s_package.name }} : run Shell Script : {{ k8s_package_manifest }}"
+  become: yes
+  become_user: "{{ k8s_state_user }}"
   shell:
     cmd: bash '{{ k8s_package_manifest }}'
     chdir: "{{ k8s_state_source_location }}"

--- a/site.yml
+++ b/site.yml
@@ -1,5 +1,13 @@
 ---
 
+- name: gather facts
+  hosts: localhost
+  connection: local
+  tasks:
+    - name: get user
+      set_fact:
+        k8s_state_user: "{{ lookup('env', 'K8S_STATE_USER') | default('nobody') }}"
+
 - name: apply desired state
   hosts: localhost
   connection: local


### PR DESCRIPTION
This PR provides the following changes:

 - [x] :whale: Add `klifter-agent` user to run the playbook
 - [x] :whale: Add `klifter-restricted` user to run shell manifests
 - [x] :lock: Shell manifest tasks become user `klifter-restricted`
 - [x] :wrench: Add `K8S_STATE_USER` environment variable to configure the restricted user's name (defaults to `nobody`)