### PR TITLE
🐛 Fix k8s-state role

### DIFF
--- a/roles/k8s-state/tasks/application.yml
+++ b/roles/k8s-state/tasks/application.yml
@@ -17,5 +17,5 @@
   changed_when: false
 
 - name: "{{ k8s_package.name }} : deploy application"
-  shell: kapp deploy -n 'klifter-system-app-{{ k8s_package.name }}' -a '{{ k8s_package.name }}' -f '{{ k8s_state_source_location }}/apps/{{ k8s_package.name }}'
+  shell: kapp deploy --yes -n 'klifter-system-app-{{ k8s_package.name }}' -a '{{ k8s_package.name }}' -f '{{ k8s_state_source_location }}/apps/{{ k8s_package.name }}'
   changed_when: false

--- a/roles/k8s-state/tasks/main.yml
+++ b/roles/k8s-state/tasks/main.yml
@@ -7,7 +7,7 @@
     loop_var: k8s_tool
 
 - name: deploy packages
-  include_tasks: "{{ package.kind }}.yml"
+  include_tasks: "{{ k8s_package.kind }}.yml"
   loop: "{{ k8s_state_source_vars.packages }}"
   loop_control:
     loop_var: k8s_package


### PR DESCRIPTION
This PR provides the following changes:

 - [x] :bug: Make `kapp` non interactive
 - [x] :bug: Include correct task paths