### PR TITLE
🐳🔒 Share home directory between both klifter users

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,11 @@ ADD . /workspace
 WORKDIR /workspace
 
 RUN set -ex && \
-    useradd -s /bin/bash -d /workspace klifter-agent && \
-    chown -R klifter-agent:klifter-agent /workspace && \
-    useradd -ms /bin/bash klifter-restricted && \
+    groupadd klifter && \
+    useradd -s /bin/bash -d /workspace -g klifter klifter-agent && \
+    useradd -s /bin/bash -d /workspace -g klifter klifter-restricted && \
+    chown -R klifter-agent:klifter /workspace && \
+    chmod -R g+rw /workspace && \
     echo "klifter-agent ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/klifter
 
 USER klifter-agent


### PR DESCRIPTION
This PR provides the following changes:

 - [x] :sparkles: Add group `klifter`
 - [x] :wrench: Set `/workspace` as home directory for users `klifter-agent` and `klifter-restricted`
 - [x] :lock: Set `klifter` group as owner group for `/workspace`
 - [x] :lock: Add read/write permissions to group owner in `/workspace`

This ensure that `klifter-agent` and `klifter-restricted` are almost the same user but only `klifter-agent` is authorized to use `sudo`.

Bash manifests now works transparently as before.